### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "datafusion",
     "name_pretty": "Cloud Data Fusion",
     "product_documentation": "https://cloud.google.com/data-fusion",
-    "client_documentation": "https://googleapis.dev/python/datafusion/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/datafusion/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ data from siloed on-premises platforms.
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-data-fusion.svg
    :target: https://pypi.org/project/google-cloud-data-fusion/
 .. _Cloud Data Fusion: https://cloud.google.com/data-fusion
-.. _Client Library Documentation: https://googleapis.dev/python/datafusion/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/datafusion/latest
 .. _Product Documentation:  https://cloud.google.com/data-fusion/docs
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.